### PR TITLE
Update JackTokenizer.java

### DIFF
--- a/projects/10/Complier/src/SyntaxAnalyzer/JackTokenizer.java
+++ b/projects/10/Complier/src/SyntaxAnalyzer/JackTokenizer.java
@@ -140,7 +140,7 @@ public class JackTokenizer {
         symbolReg = "[\\&\\*\\+\\(\\)\\.\\/\\,\\-\\]\\;\\~\\}\\|\\{\\>\\=\\[\\<]";
         intReg = "[0-9]+";
         strReg = "\"[^\"\n]*\"";
-        idReg = "[\\w_]+";
+        idReg = "[\\w_][\\w\\d_]*";
 
         tokenPatterns = Pattern.compile(keyWordReg + symbolReg + "|" + intReg + "|" + strReg + "|" + idReg);
     }


### PR DESCRIPTION
change idReg in order to support the statement in the lecturer:
identifier: a sequence of letters, digits, and underscore ( '_' ) not starting with a digit.